### PR TITLE
Optional param for vibrate() and added cancel()

### DIFF
--- a/android/src/main/java/flutter/plugins/vibrate/vibrate/VibratePlugin.java
+++ b/android/src/main/java/flutter/plugins/vibrate/vibrate/VibratePlugin.java
@@ -28,18 +28,26 @@ public class VibratePlugin implements MethodCallHandler {
 
   @Override
   public void onMethodCall(MethodCall call, Result result) {
-    if (call.method.equals("vibrate")) {
-      if(_vibrator.hasVibrator()){
-        int duration = call.argument("duration");
-        _vibrator.vibrate(duration);
-      }
-      result.success(null);
-    }
-    else if(call.method.equals("canVibrate")){
-      result.success(_vibrator.hasVibrator());
-    }
-    else {
-      result.notImplemented();
+    switch (call.method) {
+      case "vibrate":
+        if (_vibrator.hasVibrator()) {
+          int duration = call.argument("duration");
+          _vibrator.vibrate(duration);
+        }
+        result.success(null);
+        break;
+      case "canVibrate":
+        result.success(_vibrator.hasVibrator());
+        break;
+      case "cancel":
+        if (_vibrator.hasVibrator()) {
+          _vibrator.cancel();
+        }
+        result.success(null);
+        break;
+      default:
+        result.notImplemented();
+        break;
     }
   }
 }

--- a/ios/Classes/VibratePlugin.m
+++ b/ios/Classes/VibratePlugin.m
@@ -18,6 +18,10 @@
   else if ([@"canVibrate" isEqualToString:call.method]){
     result([NSNumber numberWithBool:YES]);
   }
+  else if ([@"cancel" isEqualToString:call.method]){
+    //TODO add cancel functionality to iOS
+    result(nil);
+  }
   else {
     result(FlutterMethodNotImplemented);
   }

--- a/lib/vibrate.dart
+++ b/lib/vibrate.dart
@@ -7,7 +7,7 @@ class Vibrate {
   static const Duration _DEFAULT_VIBRATION_DURATION = const Duration(milliseconds: 500);
 
   //Vibrate for 500ms on Android, and for the default time on iOS (about 500ms as well)
-  static Future vibrate() => _channel.invokeMethod('vibrate', {"duration" : _DEFAULT_VIBRATION_DURATION.inMilliseconds});
+  static Future vibrate([Duration duration = _DEFAULT_VIBRATION_DURATION]) => _channel.invokeMethod('vibrate', {"duration": duration.inMilliseconds});
   //Whether the device can actually vibrate or not
   static Future<bool> get canVibrate => _channel.invokeMethod('canVibrate');
   /**

--- a/lib/vibrate.dart
+++ b/lib/vibrate.dart
@@ -25,4 +25,7 @@ class Vibrate {
     }
     vibrate();
   }
+
+  //Cancel vibrations
+  static Future cancel() => _channel.invokeMethod("cancel");
 }


### PR DESCRIPTION
For Android, I also changed the if statements in `onMethodCall` to a switch case. 
I do not know how to do stuff for iOS, so I only implemented a TODO line for cancel().