### PR TITLE
Allow client to set custom duration

### DIFF
--- a/lib/vibrate.dart
+++ b/lib/vibrate.dart
@@ -7,7 +7,7 @@ class Vibrate {
   static const Duration _DEFAULT_VIBRATION_DURATION = const Duration(milliseconds: 500);
 
   //Vibrate for 500ms on Android, and for the default time on iOS (about 500ms as well)
-  static Future vibrate() => _channel.invokeMethod('vibrate', {"duration" : _DEFAULT_VIBRATION_DURATION.inMilliseconds});
+  static Future vibrate({Duration duration = _DEFAULT_VIBRATION_DURATION}) => _channel.invokeMethod('vibrate', {"duration" : duration.inMilliseconds});
   //Whether the device can actually vibrate or not
   static Future<bool> get canVibrate => _channel.invokeMethod('canVibrate');
   /**


### PR DESCRIPTION
@clovisnicolas Maybe we can provide a optional duration parameter in public api so that client can set vibrate duration as they ?