### PR TITLE
Vibrate for duration (Android)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.0.3] - May 22nd, 2018.
+
+* Change ``vibrate({Duration duration : _DEFAULT_VIBRATION_DURATION})`` to accept optional parameter ``duration`` for Android devices
+* Dart 2.0 compatibility
+
 ## [0.0.2] - January 26th, 2018.
 
 * added ``vibrateWithPauses(Iterable<Duration> pauses)``

--- a/android/src/main/java/flutter/plugins/vibrate/vibrate/VibratePlugin.java
+++ b/android/src/main/java/flutter/plugins/vibrate/vibrate/VibratePlugin.java
@@ -28,14 +28,14 @@ public class VibratePlugin implements MethodCallHandler {
 
   @Override
   public void onMethodCall(MethodCall call, Result result) {
-    if (call.method.equals("vibrate")) {
+    if ("vibrate".equals(call.method)) {
       if(_vibrator.hasVibrator()){
         int duration = call.argument("duration");
         _vibrator.vibrate(duration);
       }
       result.success(null);
     }
-    else if(call.method.equals("canVibrate")){
+    else if("canVibrate".equals(call.method)) {
       result.success(_vibrator.hasVibrator());
     }
     else {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:vibrate/vibrate.dart';
 
@@ -9,13 +11,17 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-
   bool _canVibrate = true;
-  final Iterable<Duration> pauses = [
+
+  final Iterable<Duration> _pauses = const [
     const Duration(milliseconds: 500),
     const Duration(milliseconds: 1000),
     const Duration(milliseconds: 500),
   ];
+
+  bool _supportsCustomDuration = false;
+
+  Duration _duration = const Duration(milliseconds: 1000);
 
   @override
   initState() {
@@ -23,9 +29,12 @@ class _MyAppState extends State<MyApp> {
     init();
   }
 
-  init() async{
+  init() async {
     bool canVibrate = await Vibrate.canVibrate;
-    setState((){_canVibrate = canVibrate;});
+    setState(() {
+      _canVibrate = canVibrate;
+      _supportsCustomDuration = Platform.operatingSystem == "android";
+    });
   }
 
   @override
@@ -34,17 +43,42 @@ class _MyAppState extends State<MyApp> {
       home: new Scaffold(
         appBar: new AppBar(title: new Text('Plugin example app')),
         body: new Center(
-          child: new Column(
-            children: <Widget>[
-              new ListTile(
+          child: new Column(children: <Widget>[
+            new ListTile(
                 leading: new Icon(Icons.vibration, color: Colors.teal),
-                onTap: _canVibrate ?(){Vibrate.vibrate();} : null,
-                title: new Text("Vibrate")),
-              new ListTile(
-                  leading: new Icon(Icons.vibration, color: Colors.blue),
-                  onTap: _canVibrate ?(){Vibrate.vibrateWithPauses(pauses);} : null,
-                  title: new Text("Vibrate with pauses")),
-            ]),
+                onTap: _canVibrate
+                    ? () {
+                        if (_supportsCustomDuration) {
+                          Vibrate.vibrate(duration: _duration);
+                        } else {
+                          Vibrate.vibrate();
+                        }
+                      }
+                    : null,
+                title: new Text("Vibrate"),
+                subtitle: _supportsCustomDuration
+                    ? new Row(children: <Widget>[
+                        new Slider(
+                            min: 500.0,
+                            max: 5000.0,
+                            value: _duration.inMilliseconds.roundToDouble(),
+                            onChanged: (double value) {
+                              setState(() {
+                                _duration = new Duration(milliseconds: value.round());
+                              });
+                            }),
+                        new Text("${_duration.inMilliseconds} ms"),
+                      ])
+                    : null),
+            new ListTile(
+                leading: new Icon(Icons.vibration, color: Colors.blue),
+                onTap: _canVibrate
+                    ? () {
+                        Vibrate.vibrateWithPauses(_pauses);
+                      }
+                    : null,
+                title: new Text("Vibrate with pauses")),
+          ]),
         ),
       ),
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,7 +33,7 @@ class _MyAppState extends State<MyApp> {
     bool canVibrate = await Vibrate.canVibrate;
     setState(() {
       _canVibrate = canVibrate;
-      _supportsCustomDuration = Platform.operatingSystem == "android";
+      _supportsCustomDuration = Platform.operatingSystem != "ios";
     });
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,7 +33,7 @@ class _MyAppState extends State<MyApp> {
     bool canVibrate = await Vibrate.canVibrate;
     setState(() {
       _canVibrate = canVibrate;
-      _supportsCustomDuration = Platform.operatingSystem != "ios";
+      _supportsCustomDuration = !Platform.isIOS;
     });
   }
 

--- a/lib/vibrate.dart
+++ b/lib/vibrate.dart
@@ -11,7 +11,7 @@ class Vibrate {
    * Vibrate for specified duration on Android, and for the default time of 500ms on iOS
    */
   static Future vibrate({Duration duration : _DEFAULT_VIBRATION_DURATION}) {
-    if(Platform.operatingSystem == "ios" && duration != _DEFAULT_VIBRATION_DURATION) {
+    if(Platform.isIOS && duration != _DEFAULT_VIBRATION_DURATION) {
       throw new UnsupportedError("iOS only supports default duration of ${_DEFAULT_VIBRATION_DURATION.inMilliseconds} ms");
     }
     return _channel.invokeMethod('vibrate', {"duration" : duration.inMilliseconds});

--- a/lib/vibrate.dart
+++ b/lib/vibrate.dart
@@ -6,10 +6,16 @@ class Vibrate {
   static const MethodChannel _channel = const MethodChannel('github.com/clovisnicolas/flutter_vibrate');
   static const Duration _DEFAULT_VIBRATION_DURATION = const Duration(milliseconds: 500);
 
-  //Vibrate for 500ms on Android, and for the default time on iOS (about 500ms as well)
-  static Future vibrate() => _channel.invokeMethod('vibrate', {"duration" : _DEFAULT_VIBRATION_DURATION.inMilliseconds});
-  //Whether the device can actually vibrate or not
-  static Future<bool> get canVibrate => _channel.invokeMethod('canVibrate');
+  /**
+   * Vibrate for specified duration on Android, and for the default time of 500ms on iOS
+   */
+  static Future vibrate({Duration duration : _DEFAULT_VIBRATION_DURATION}) => _channel.invokeMethod('vibrate', {"duration" : duration.inMilliseconds});
+
+  /**
+   * Whether the device can actually vibrate or not
+   */
+  static Future<bool> get canVibrate async => await _channel.invokeMethod('canVibrate');
+
   /**
   Vibrates with [pauses] in between each vibration
   Will always vibrate once before the first pause

--- a/lib/vibrate.dart
+++ b/lib/vibrate.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/services.dart';
 
@@ -9,7 +10,12 @@ class Vibrate {
   /**
    * Vibrate for specified duration on Android, and for the default time of 500ms on iOS
    */
-  static Future vibrate({Duration duration : _DEFAULT_VIBRATION_DURATION}) => _channel.invokeMethod('vibrate', {"duration" : duration.inMilliseconds});
+  static Future vibrate({Duration duration : _DEFAULT_VIBRATION_DURATION}) {
+    if(Platform.operatingSystem == "ios" && duration != _DEFAULT_VIBRATION_DURATION) {
+      throw new UnsupportedError("iOS only supports default duration of ${_DEFAULT_VIBRATION_DURATION.inMilliseconds} ms");
+    }
+    return _channel.invokeMethod('vibrate', {"duration" : duration.inMilliseconds});
+  }
 
   /**
    * Whether the device can actually vibrate or not

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vibrate
 description: A flutter plugin to vibrate the device
-version: 0.0.2
+version: 0.0.3
 author: Clovis Nicolas <clovisnicolas0@gmail.com>
 homepage: https://github.com/clovisnicolas/flutter_vibrate
 


### PR DESCRIPTION
* Change ``vibrate({Duration duration : _DEFAULT_VIBRATION_DURATION})`` to accept optional parameter ``duration`` for Android devices. Throw UnsupportedError on iOS if duration has been passed.
* Dart 2.0 compatibility
* Add custom duration to example app